### PR TITLE
fix:编译安装core时路径错误

### DIFF
--- a/docs/dev/build.md
+++ b/docs/dev/build.md
@@ -34,7 +34,7 @@ mkdir /opt/jumpserver-{{ jumpserver.version }}
 wget -O /opt/jumpserver-{{ jumpserver.version }}.tar.gz https://github.com/jumpserver/jumpserver/archive/refs/tags/{{ jumpserver.version }}.tar.gz
 tar -xf jumpserver-{{ jumpserver.version }}.tar.gz -C /opt/jumpserver-{{ jumpserver.version }} --strip-components 1
 cd jumpserver-{{ jumpserver.version }}
-wget https://download.jumpserver.org/files/GeoLite2-City.mmdb -O apps/common/utils/geoip/GeoLite2-City.mmdb
+wget https://download.jumpserver.org/files/GeoLite2-City.mmdb -O apps/common/utils/ip/geoip/GeoLite2-City.mmdb
 ```
 
 ```bash


### PR DESCRIPTION
执行下载命令wget https://download.jumpserver.org/files/GeoLite2-City.mmdb -O apps/common/utils/geoip/GeoLite2-City.mmdb报错：apps/common/utils/geoip/GeoLite2-City.mmdb：No such file or directory

当前安装包中的路径为/opt/jumpserver-v2.22.0/apps/common/utils/ip/geoip