### PR TITLE
fix: 修正Core部署时安装Python的命令

### DIFF
--- a/docs/installation/source_install/core_install.md
+++ b/docs/installation/source_install/core_install.md
@@ -55,7 +55,7 @@
 
 !!! tip ""
     ```bash
-    apt-get install -y python3.9 python3.9-dev python3-venv
+    apt-get install -y python3.9 python3.9-dev python3.9-venv
     ```
     ```bash
     python3.9

--- a/docs/installation/source_install/lina_install.md
+++ b/docs/installation/source_install/lina_install.md
@@ -29,9 +29,9 @@
         === "Ubuntu 20.04"
             ```bash
             cd /opt
-            wget https://nodejs.org/download/release/v16.5/node-v16.5-linux-x64.tar.xz
-            tar -xf node-v16.5-linux-x64.tar.xz
-            mv node-v16.5-linux-x64 /usr/local/node
+            wget https://nodejs.org/download/release/v16.5.0/node-v16.5.0-linux-x64.tar.xz
+            tar -xf node-v16.5.0-linux-x64.tar.xz
+            mv node-v16.5.0-linux-x64 /usr/local/node
             chown -R root:root /usr/local/node
             export PATH=/usr/local/node/bin:$PATH
             echo 'export PATH=/usr/local/node/bin:$PATH' >> ~/.bashrc

--- a/docs/installation/source_install/merge_jumpserver.md
+++ b/docs/installation/source_install/merge_jumpserver.md
@@ -16,7 +16,7 @@
           listen 80;
           # server_name _;
 
-          client_max_body_size 5000m; 文件大小限制
+          client_max_body_size 5000m; # 文件大小限制
 
           # Luna 配置
           location /luna/ {
@@ -112,7 +112,7 @@
           listen 80;
           # server_name _;
 
-          client_max_body_size 5000m; 文件大小限制
+          client_max_body_size 5000m; # 文件大小限制
 
           # 前端 Lina
           location /ui/ {


### PR DESCRIPTION
安装 Python 的命令应该是写错了，会导致下一步 `python3.9 -m venv /opt/py3` 命令报错。